### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ariellourenco/life/security/code-scanning/1](https://github.com/ariellourenco/life/security/code-scanning/1)

To implement the fix, add a `permissions` block specifying minimal required access. For this type of build-and-test workflow (which does not interact with issues, PRs, or push artifacts), the minimal permission is typically `contents: read`, which enables access to the source code but prevents unnecessary writes. Insert this block either at the workflow root (below `name:` and above `on:`), or at the job level under `build:` (indented appropriately).

The best practice is to set it at the root unless some jobs require different permissions.  
**Steps:**
- Edit `.github/workflows/dotnet.yml`.
- Insert:
```yaml
permissions:
  contents: read
```
- Place directly below the `name:` key (between lines 4 and 6).

No imports, method changes, or definitions are needed for this YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
